### PR TITLE
ADD entries in errata

### DIFF
--- a/EssentialC#6 Errata.md
+++ b/EssentialC#6 Errata.md
@@ -12,7 +12,7 @@ The following corrections will be made in the second printing. (To determine whi
 
 Chapter     | Page         | Correction 
 ----------- | ------------ | ---------- 
-1           | 14           | Listing 1.9: The class name of `miracleMax` uses camel case, which violates the guideline given previously on page 8 to use Pascal case for all class names. The class name should be `MiracleMax`.
+1           | 14           | Listing 1.9: The class name should be `MiracleMax`. (The camelCase name of `miracleMax` must have occurred in a rename that wasn't caught during editing.) 
 1           | 16           | Listing 1.11: The second assignment of `miracleMax` was incorrectly made instead to an undeclared variable named `max`. The correct line of code is `miracleMax = "It would take a miracle.";` 
 1           | 22           | Listing 1.18 is a modification of Listing 1.16, not 1.15.
 2           | 38           | Table 2.2: The literal suffix for the `double` type is incorrect. It should be `D or d`.

--- a/EssentialC#6 Errata.md
+++ b/EssentialC#6 Errata.md
@@ -15,6 +15,7 @@ Chapter     | Page         | Correction
 1           | 14           | Listing 1.9: The class name of `miracleMax` uses camel case, which violates the guideline given previously on page 8 to use Pascal case for all class names. The class name should be `MiracleMax`.
 1           | 16           | Listing 1.11: The second assignment of `miracleMax` was incorrectly made instead to an undeclared variable named `max`. The correct line of code is `miracleMax = "It would take a miracle.";` 
 1           | 22           | Listing 1.18 is a modification of Listing 1.16, not 1.15.
+2           | 38           | Table 2.2: The literal suffix for the `double` type is incorrect. It should be `D or d`.
 2           | 52           | Table 2.5: The last string.Compare statement contains two errors (a round bracket after strB parameter instead of a comma and ignoreCase should be bool instead of string). The correct statement is "static int string.Compare(string strA, string strB, bool ignoreCase)" 
 3           | 116          | System.Math.E was referred to as Euler's constant, but this is in fact Euler's number.
 6           | 294          | The sentence that reads “The C# compiler allows the cast operator even when the type hierarchy allows an implicit cast” should instead read “… allows an implicit **conversion**.” <br><br> The second example on the page should read “or even when no **conversion** is necessary.” 

--- a/EssentialC#6 Errata.md
+++ b/EssentialC#6 Errata.md
@@ -12,6 +12,7 @@ The following corrections will be made in the second printing. (To determine whi
 
 Chapter     | Page         | Correction 
 ----------- | ------------ | ---------- 
+1           | 14           | Listing 1.9: The class name of `miracleMax` uses camel case, which violates the guideline given previously on page 8 to use Pascal case for all class names. The class name should be `MiracleMax`.
 1           | 16           | Listing 1.11: The second assignment of `miracleMax` was incorrectly made instead to an undeclared variable named `max`. The correct line of code is `miracleMax = "It would take a miracle.";` 
 1           | 22           | Listing 1.18 is a modification of Listing 1.16, not 1.15.
 2           | 52           | Table 2.5: The last string.Compare statement contains two errors (a round bracket after strB parameter instead of a comma and ignoreCase should be bool instead of string). The correct statement is "static int string.Compare(string strA, string strB, bool ignoreCase)" 


### PR DESCRIPTION
# Overview

This PR adds some entries in the errata document for Essential C# 6.0. The entries relate to:

1. Listing 1.9 from chapter 1, page 14
2. Table 2.2 from chapter 2, page 38