### PR TITLE
V7.0 nuget

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+  <!-- MSTest adapter -->
+  <!--
+  <MSTest>
+    <Parallelize>
+      <Workers>4</Workers>
+      <Scope>ProcessLevel</Scope>
+    </Parallelize>
+  </MSTest>
+  -->
+</RunSettings>

--- a/Essential-C#-v7.0-Errata.md
+++ b/Essential-C#-v7.0-Errata.md
@@ -1,0 +1,15 @@
+# Essential C# 7.0 Errata Document
+
+## Essential C# 7.0
+by Mark Michaelis
+ISBN-13: 978-1-5093-0358-8
+IISBN-10: 1-5093-0358-8
+Copyright © 2018 Pearson Education, Inc.
+
+First printing, September 2015
+
+The following corrections will be made in the second printing. (To determine which printing you have, turn to page IV of your book. The last line on that page contains the printing information.)
+
+Found by     |Chapter     | Page         | Correction
+------------ |----------- | ------------ | ----------
+Zhou Jing    |7           | 329          | Listing 7.13: The `Run()` method should be public, `private void Run()`.

--- a/EssentialCSharp.sln
+++ b/EssentialCSharp.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F97BC459-B5B9-4326-9E0D-D085FD4DEF96}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		.runsettings = .runsettings
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/Chapter07/Listing07.13.ForcingTheDesirableRunSemantics.cs
+++ b/src/Chapter07/Listing07.13.ForcingTheDesirableRunSemantics.cs
@@ -7,7 +7,7 @@
             // Critical code
         }
 
-        private void Run()
+        public void Run()
         {
             Start();
             InternalRun();

--- a/src/ChapterTests.targets
+++ b/src/ChapterTests.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="IntelliTect.TestTools.Console" Version="1.0.0" Condition="!Exists('..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj')" />
+    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" Condition="Exists('..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj')" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
These code changes will prevent the user from having to deal with submodules.  Instead, they will automatically grab v1.0.0 release of IntelliTect.TestTools.Console. These changes work with the already submitted changes to TestTools.