### PR TITLE
Submodule and nuget support for TestTools

### DIFF
--- a/src/Chapter01.Tests/Chapter01.Tests.csproj
+++ b/src/Chapter01.Tests/Chapter01.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter01.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter01\Chapter01.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter02.Tests/Chapter02.Tests.csproj
+++ b/src/Chapter02.Tests/Chapter02.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter02.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter02\Chapter02.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter03.Tests/Chapter03.Tests.csproj
+++ b/src/Chapter03.Tests/Chapter03.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter03.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter03\Chapter03.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter04.Tests/Chapter04.Tests.csproj
+++ b/src/Chapter04.Tests/Chapter04.Tests.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ProductName>Chapter04.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter04\Chapter04.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter05.Tests/Chapter05.Tests.csproj
+++ b/src/Chapter05.Tests/Chapter05.Tests.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ProductName>Chapter05.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter05\Chapter05.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter06.Tests/Chapter06.Tests.csproj
+++ b/src/Chapter06.Tests/Chapter06.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter08.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter06\Chapter06.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter07.Tests/Chapter07.Tests.csproj
+++ b/src/Chapter07.Tests/Chapter07.Tests.csproj
@@ -1,18 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ProductName>Chapter07.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter07\Chapter07.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Chapter08.Tests/Chapter08.Tests.csproj
+++ b/src/Chapter08.Tests/Chapter08.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter08.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter08\Chapter08.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter09.Tests/Chapter09.Tests.csproj
+++ b/src/Chapter09.Tests/Chapter09.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter09.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter09\Chapter09.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Chapter10.Tests/Chapter10.Tests.csproj
+++ b/src/Chapter10.Tests/Chapter10.Tests.csproj
@@ -5,6 +5,7 @@
     <ProductName>Chapter10.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
@@ -12,7 +13,6 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter10\Chapter10.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter12.Tests/Chapter12.Tests.csproj
+++ b/src/Chapter12.Tests/Chapter12.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter12.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter12\Chapter12.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter13.Tests/Chapter13.Tests.csproj
+++ b/src/Chapter13.Tests/Chapter13.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter13.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter13\Chapter13.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter14.Tests/Chapter14.Tests.csproj
+++ b/src/Chapter14.Tests/Chapter14.Tests.csproj
@@ -5,6 +5,7 @@
     <ProductName>Chapter14.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
@@ -12,7 +13,6 @@
     <PackageReference Include="System.Reflection" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter14\Chapter14.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter15.Tests/Chapter15.Tests.csproj
+++ b/src/Chapter15.Tests/Chapter15.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter15.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter15\Chapter15.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter16.Tests/Chapter16.Tests.csproj
+++ b/src/Chapter16.Tests/Chapter16.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter16.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter16\Chapter16.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter17.Tests/Chapter17.Tests.csproj
+++ b/src/Chapter17.Tests/Chapter17.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter17.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter17\Chapter17.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter18.Tests/Chapter18.Tests.csproj
+++ b/src/Chapter18.Tests/Chapter18.Tests.csproj
@@ -5,13 +5,13 @@
     <ProductName>Chapter18.Tests</ProductName>
   </PropertyGroup>
   <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter18\Chapter18.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Chapter19.Tests/Chapter19.Tests.csproj
+++ b/src/Chapter19.Tests/Chapter19.Tests.csproj
@@ -1,22 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
+  <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter19\Chapter19.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/src/Chapter20.Tests/Chapter20.Tests.csproj
+++ b/src/Chapter20.Tests/Chapter20.Tests.csproj
@@ -1,22 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
+  <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter20\Chapter20.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/src/Chapter21.Tests/Chapter21.Tests.csproj
+++ b/src/Chapter21.Tests/Chapter21.Tests.csproj
@@ -1,22 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
+  <Import Project="..\Versioning.targets" />
+  <Import Project="..\ChapterTests.targets"/>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170727-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0-beta" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0-beta" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" />
     <ProjectReference Include="..\Chapter21\Chapter21.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/src/ChapterTests.targets
+++ b/src/ChapterTests.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="IntelliTect.TestTools.Console" Version="1.0.0-*" Condition="!Exists('..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj')" />
+    <ProjectReference Include="..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj" Condition="Exists('..\submodules\TestTools\IntelliTect.TestTools.Console\IntelliTect.TestTools.Console.csproj')" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
These code changes will prevent the user from having to deal with submodules. Instead, they will automatically grab v1.0.0 release of IntelliTect.TestTools.Console. These changes work with the already submitted changes to TestTools.