### PR TITLE
Addressed extra Read() when task was completed

### DIFF
--- a/src/Chapter21/Listing21.10.CancelingParallelLoop.cs
+++ b/src/Chapter21/Listing21.10.CancelingParallelLoop.cs
@@ -50,7 +50,6 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
                 // Cancel which ever task has not finished.
                 cts.Cancel();
                 await task;
-                await Task.FromCanceled(cts.Token);
 
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("\nCompleted successfully");
@@ -68,27 +67,26 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
         private static async Task<int> ConsoleReadAsync(
             CancellationToken cancellationToken = default)
         {
-            int result = 0;
-            await Task.Run(async () =>
+            return await Task.Run(async () =>
             {
                 const int maxDelay = 1025;
-                int delay = 1;
+                int delay = 0;
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     if (Console.KeyAvailable)
                     {
-                        result = Console.Read();
-                        break;
+                        return Console.Read();
                     }
                     else
                     {
                         await Task.Delay(delay,cancellationToken);
-                        if (delay < maxDelay) delay *= 2;
+                        if (delay < maxDelay) delay *= 2 + 1;
                     }
                 }
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new InvalidOperationException(
+                    "Previous line should throw preventing this fromever executing");
             }, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-            return result;
         }
 
         private static string Encrypt(string item)

--- a/src/Chapter21/Listing21.10.CancelingParallelLoop.cs
+++ b/src/Chapter21/Listing21.10.CancelingParallelLoop.cs
@@ -33,7 +33,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
             ConsoleColor originalColor = Console.ForegroundColor;
             List<string> data = Utility.GetData(100000).ToList();
 
-            CancellationTokenSource cts =
+            using CancellationTokenSource cts =
                 new CancellationTokenSource();
 
             Task task = Task.Run(() =>
@@ -41,7 +41,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
                 data = ParallelEncrypt(data, cts.Token);
             }, cts.Token);
 
-            Console.WriteLine("Push ENTER to Exit.");
+            Console.WriteLine("Push any key to Exit.");
             Task<int> cancelTask = ConsoleReadAsync(cts.Token);
 
             try
@@ -50,6 +50,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
                 // Cancel which ever task has not finished.
                 cts.Cancel();
                 await task;
+                await Task.FromCanceled(cts.Token);
 
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("\nCompleted successfully");
@@ -70,8 +71,8 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
             int result = 0;
             await Task.Run(async () =>
             {
-                int maxDelay = 1025;
-                int delay = 0;
+                const int maxDelay = 1025;
+                int delay = 1;
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     if (Console.KeyAvailable)
@@ -81,7 +82,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
                     }
                     else
                     {
-                        await Task.Delay(delay);
+                        await Task.Delay(delay,cancellationToken);
                         if (delay < maxDelay) delay *= 2;
                     }
                 }

--- a/src/Chapter21/Listing21.10.CancelingParallelLoop.cs
+++ b/src/Chapter21/Listing21.10.CancelingParallelLoop.cs
@@ -50,7 +50,6 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
                 // Cancel which ever task has not finished.
                 cts.Cancel();
                 await task;
-                await cancelTask;
 
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("\nCompleted successfully");
@@ -59,8 +58,8 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter21.Listing21_10
             catch(OperationCanceledException taskCanceledException)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($@"\nCancelled: {
-                    taskCanceledException.Message }");
+                Console.WriteLine(
+                    $"\nCancelled: { taskCanceledException.Message }");
             }
             Console.ForegroundColor = originalColor;
         }


### PR DESCRIPTION
Added an `ConsoleReadAsync()` method but would appreciate a second pair of eyes on the implementation.  The purpose of the method is to provide a way to simulate cancelling a console.Read().