### PR TITLE
Add coverlet collector for code coverage creation via dotnet test

### DIFF
--- a/src/ChapterTests.props
+++ b/src/ChapterTests.props
@@ -10,6 +10,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="coverlet.msbuild" Version="3.0.0" />
     <!--<PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.3" />-->
     <!--<PackageReference Update="MSTest.TestAdapter" Version="2.1.2" />-->


### PR DESCRIPTION
When dotnet Test  (Test Execution Command Line Tool) Version 16.8.1 changed to 16.8.3 code coverage stopped being published. Now need to use coverlet collector