### PR TITLE
Rename, and use 2 ManualResetEventSlim to ensure that Post is called 2x

### DIFF
--- a/src/Chapter20.Tests/Listing20.09.CatchingAnExceptionFromAnAsyncVoidMethodTests.cs
+++ b/src/Chapter20.Tests/Listing20.09.CatchingAnExceptionFromAnAsyncVoidMethodTests.cs
@@ -1,5 +1,5 @@
 
-namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_11
+namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_9
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
@@ -8,7 +8,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_11
     using AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_09;
 
     [TestClass]
-    public class ProgramTests
+    public class CatchingAnExceptionFromAnAsyncVoidMethodProgramTests
     {
 
         [TestMethod]


### PR DESCRIPTION
On the linux os the Post method wasn't being called twice, and the console test expected it to be called twice. Added a second ManualResetEventSlim to demonstrate that the Post method gets called twice as well as ensure it is called twice before the program continues.

See the test assertion error here https://dev.azure.com/intelliTect/EssentialCSharp/_build/results?buildId=12279&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=4984a880-4513-5ca9-0be3-251146e4056b&l=264