### PR TITLE
Rename Test to appropriate name

### DIFF
--- a/src/Chapter20.Tests/Listing20.09.CatchingAnExceptionFromAnAsyncVoidMethodProgramTests.cs
+++ b/src/Chapter20.Tests/Listing20.09.CatchingAnExceptionFromAnAsyncVoidMethodProgramTests.cs
@@ -1,14 +1,12 @@
 
-namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_11
+namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_09
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
-    using AddisonWesley.Michaelis.EssentialCSharp.Chapter20.Listing20_09;
 
     [TestClass]
-    public class ProgramTests
+    public class CatchingAnExceptionFromAnAsyncVoidMethodProgramTests
     {
 
         [TestMethod]


### PR DESCRIPTION
This test still has inconsistent results between Linux and Windows due to the thread context...

Just renaming it to match the books listing