### PR TITLE
Updated Chapters 2/3/4 with corrections

### DIFF
--- a/.github/workflows/Branch v8.0 - Linux.yml
+++ b/.github/workflows/Branch v8.0 - Linux.yml
@@ -13,14 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: v8.0
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - name: Get Directory
-      run: pwd
+    - name: Get Build Information
+      run: |
+        pwd
+        dotnet --info
+        dotnet --version
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/Branch v8.0 - Windows.yml
+++ b/.github/workflows/Branch v8.0 - Windows.yml
@@ -13,14 +13,15 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: v8.0
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - name: Get Directory
-      run: pwd
+    - name: Get Build Information
+      run: |
+        pwd
+        dotnet --info
+        dotnet --version
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Errata.md
+++ b/Errata.md
@@ -15,6 +15,12 @@ Salim Gangji        | 1           | 12          | First paragraph: For a single 
 Pieter Le Roux      | 1           | 31          | Last Line: Table 1.2 shows four different C# comment types. The program in <s>Listing 1.18</s> Listing 1.19 includes two of these.
 Benjamin Michaelis  | 1           | 31          | Last Line: Table 1.2 shows four different C# comment types. The program in Listing 1.19 includes <s>two</s>three of these.
 Salim Gangji        | 2           | 51          | Output 2.3: <s>1.61803398874985</s> 1.618033988749895
+Alden Bansemer      | 2           | 55          | Listing 2.9: <s>`result == number`</s> `{result} == {number}`. Output 2.7: <s>`result == number`</s> `1.61803398874989 == 1.61803398874989`.
+Alden Bansemer      | 3           | 89          | Listing 3.4: Changed <s>`class 3.2->3.Uppercase`</s> to match source `class Uppercase`.
+Alden Bansemer      | 3           | 113         | Output 3.2: `TypeScript` replaced with `Visual Basic` as last element in sorted array and first element in the reversed, sorted array.
+Alden Bansemer      | 3           | 114         | Output 3.3: Added missing second line of output: `3`.
+Alden Bansemer      | 4           | 129         | Listing 4.7: Removed Trace.Assert to match codebase. Removed example #4, float converted to double now matches the double.
+Alden Bansemer      | 4           | 130         | Output 4.6: Updated results of Listing 4.7 to remove <s>`4.20000006258488 != 4.20000028610229`</s>.
 Pieter Le Roux      | 5           | 215         | Output 5.4: ERROR:  You must specify the URL <s>to be downloaded</s> and the file name **Usage:** Downloader.exe <URL> <TargetFileName> 
 Pieter Le Roux      | 6           | 285         | Last Line in second paragraph: "DO use nameof for the paramName argument passed into exceptions like Argument<s>Null</s>Exception and ArgumentNullException that take such a parameter. For more information, see Chapter 18."
 Pieter Le Roux      | 7           | 359         | return <s>@</s>$"FirstName: { FirstName + NewLine }" + $"LastName: { LastName + NewLine }"+ $"Address: { Address + NewLine }";

--- a/src/Chapter02/Listing02.15.UsingStaticDirectives.cs
+++ b/src/Chapter02/Listing02.15.UsingStaticDirectives.cs
@@ -1,9 +1,9 @@
 namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter02.Listing02_15
 { 
     using static System.Console;
-    class HeyYou
+    public class HeyYou
     {
-        static void Main()
+        public static void Main()
         {
             string firstName;
             string lastName;

--- a/src/Chapter02/Listing02.17.Error-StringIsImmutable.cs
+++ b/src/Chapter02/Listing02.17.Error-StringIsImmutable.cs
@@ -9,7 +9,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter02.Listing02_17
             System.Console.Write("Enter text: ");
             text = System.Console.ReadLine();
 
-            //UNEXPECTED: Does not convert text to uppercase
+            // UNEXPECTED: Does not convert text to uppercase
             text.ToUpper();
 
             System.Console.WriteLine(text);

--- a/src/Chapter03.Tests/Listing03.27.Slicing.cs
+++ b/src/Chapter03.Tests/Listing03.27.Slicing.cs
@@ -11,11 +11,11 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
             const string expected =
 @"  0..3: C#, COBOL, Java
 ^3..^0: Python, Lisp, JavaScript
- 3..^3: C++, TypeScript, Pascal
+ 3..^3: C++, TypeScript, Visual Basic
   ..^6: C#, COBOL, Java
    6..: Python, Lisp, JavaScript
-    ..: C#, COBOL, Java, C++, TypeScript, Pascal, Python, Lisp, JavaScript
-    ..: C#, COBOL, Java, C++, TypeScript, Pascal, Python, Lisp, JavaScript";
+    ..: C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript
+    ..: C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript";
 
             IntelliTect.TestTools.Console.ConsoleAssert.Expect(
                 expected, Program.Main);

--- a/src/Chapter03.Tests/Listing03.27.Slicing.cs
+++ b/src/Chapter03.Tests/Listing03.27.Slicing.cs
@@ -11,11 +11,11 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
             const string expected =
 @"  0..3: C#, COBOL, Java
 ^3..^0: Python, Lisp, JavaScript
- 3..^3: C++, TypeScript, Visual Basic
+ 3..^3: C++, TypeScript, Swift
   ..^6: C#, COBOL, Java
    6..: Python, Lisp, JavaScript
-    ..: C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript
-    ..: C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript";
+    ..: C#, COBOL, Java, C++, TypeScript, Swift, Python, Lisp, JavaScript
+    ..: C#, COBOL, Java, C++, TypeScript, Swift, Python, Lisp, JavaScript";
 
             IntelliTect.TestTools.Console.ConsoleAssert.Expect(
                 expected, Program.Main);

--- a/src/Chapter03/Listing03.09.ArrayDeclarationWithAssignment.cs
+++ b/src/Chapter03/Listing03.09.ArrayDeclarationWithAssignment.cs
@@ -5,7 +5,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_09
         public static void Main()
         {
             string[] languages = { "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript" };
         }
     }

--- a/src/Chapter03/Listing03.10.ArrayAssignmentFollowingDeclaration.cs
+++ b/src/Chapter03/Listing03.10.ArrayAssignmentFollowingDeclaration.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_10
         {
             string[] languages;
             languages = new string[] { "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript" };
         }
     }

--- a/src/Chapter03/Listing03.11.ArrayAssignmentWithNewDuringDeclaration.cs
+++ b/src/Chapter03/Listing03.11.ArrayAssignmentWithNewDuringDeclaration.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_11
         {
             string[] languages = new string[] {
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript" };
         }
     }

--- a/src/Chapter03/Listing03.12.DeclarationAndAssignmentWithTheNewKeyword.cs
+++ b/src/Chapter03/Listing03.12.DeclarationAndAssignmentWithTheNewKeyword.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_12
         {
             string[] languages = new string[9] { 
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript" };
         }
     }

--- a/src/Chapter03/Listing03.20.DeclaringAndAccessingAnArray.cs
+++ b/src/Chapter03/Listing03.20.DeclaringAndAccessingAnArray.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_20
         {
             string[] languages = new string[] {
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript"};
                 // Retrieve fifth item in languages array (TypeScript)
                 string language = languages[4];

--- a/src/Chapter03/Listing03.21.SwappingDataBetweenPositionsInAnArray.cs
+++ b/src/Chapter03/Listing03.21.SwappingDataBetweenPositionsInAnArray.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_21
         {
             string[] languages = new string[] {
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript" };
             // Save "C++" to variable called language
             string language = languages[3];

--- a/src/Chapter03/Listing03.27.Slicing.cs
+++ b/src/Chapter03/Listing03.27.Slicing.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
         {
             string[] languages = new string[] {
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Visual Basic",
+                "C++", "TypeScript", "Swift",
                 "Python", "Lisp", "JavaScript"};
 
             System.Console.WriteLine($@"  0..3: {
@@ -16,7 +16,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
                 string.Join(", ", languages[^3..^0]) // Python, Lisp, JavaScript
             }"); 
             System.Console.WriteLine($@" 3..^3: {
-                string.Join(", ", languages[3..^3]) // C++, TypeScript, Visual Basic
+                string.Join(", ", languages[3..^3]) // C++, TypeScript, Swift
             }");
             System.Console.WriteLine($@"  ..^6: {
                 string.Join(", ", languages[..^6])  // C#, COBOL, Java
@@ -25,11 +25,11 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
                 string.Join(", ", languages[6..])  // Python, Lisp, JavaScript
             }");
             System.Console.WriteLine($@"    ..: {
-                // C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript
+                // C#, COBOL, Java, C++, TypeScript, Swift, Python, Lisp, JavaScript
                 string.Join(", ", languages[..])  // Python, Lisp, JavaScript
             }");
             System.Console.WriteLine($@"    ..: {
-                // C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript
+                // C#, COBOL, Java, C++, TypeScript, Swift, Python, Lisp, JavaScript
                 string.Join(", ", languages[0..^0])  // Python, Lisp, JavaScript
             }");
         }

--- a/src/Chapter03/Listing03.27.Slicing.cs
+++ b/src/Chapter03/Listing03.27.Slicing.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
         {
             string[] languages = new string[] {
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript"};
 
             System.Console.WriteLine($@"  0..3: {
@@ -16,7 +16,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
                 string.Join(", ", languages[^3..^0]) // Python, Lisp, JavaScript
             }"); 
             System.Console.WriteLine($@" 3..^3: {
-                string.Join(", ", languages[3..^3]) // C++, TypeScript, Pascal
+                string.Join(", ", languages[3..^3]) // C++, TypeScript, Visual Basic
             }");
             System.Console.WriteLine($@"  ..^6: {
                 string.Join(", ", languages[..^6])  // C#, COBOL, Java
@@ -25,16 +25,11 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_27
                 string.Join(", ", languages[6..])  // Python, Lisp, JavaScript
             }");
             System.Console.WriteLine($@"    ..: {
-                // C#, COBOL, Java, C++, TypeScript, Pascal, Python, Lisp, JavaScript
+                // C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript
                 string.Join(", ", languages[..])  // Python, Lisp, JavaScript
             }");
-
-
-
-
-
             System.Console.WriteLine($@"    ..: {
-                // C#, COBOL, Java, C++, TypeScript, Pascal, Python, Lisp, JavaScript
+                // C#, COBOL, Java, C++, TypeScript, Visual Basic, Python, Lisp, JavaScript
                 string.Join(", ", languages[0..^0])  // Python, Lisp, JavaScript
             }");
         }

--- a/src/Chapter03/Listing03.28.AdditionalArrayMethods.cs
+++ b/src/Chapter03/Listing03.28.AdditionalArrayMethods.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_28
         {
             string[] languages = new string[]{
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Pascal",
+                "C++", "TypeScript", "Visual Basic",
                 "Python", "Lisp", "JavaScript"};
 
             System.Array.Sort(languages);

--- a/src/Chapter03/Listing03.28.AdditionalArrayMethods.cs
+++ b/src/Chapter03/Listing03.28.AdditionalArrayMethods.cs
@@ -6,7 +6,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter03.Listing03_28
         {
             string[] languages = new string[]{
                 "C#", "COBOL", "Java",
-                "C++", "TypeScript", "Visual Basic",
+                "C++", "TypeScript", "Swift",
                 "Python", "Lisp", "JavaScript"};
 
             System.Array.Sort(languages);

--- a/src/Chapter04.Tests/Listing04.02.Negative.Tests.cs
+++ b/src/Chapter04.Tests/Listing04.02.Negative.Tests.cs
@@ -8,7 +8,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter04.Listing04_02.Tests
         [TestMethod]
         public void MainTest()
         {
-            const string expected = @"-18125876697430.99";
+            const string expected = @"-26457079712930.80";
 
             IntelliTect.TestTools.Console.ConsoleAssert.Expect(
                 expected, Program.Main);

--- a/src/Chapter04/Listing04.02.Negative.cs
+++ b/src/Chapter04/Listing04.02.Negative.cs
@@ -5,7 +5,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter04.Listing04_02
         public static void Main()
         {
             //National Debt to the Penny
-            decimal debt = -28382607800141.79M;
+            decimal debt = -26457079712930.80M;
 
             System.Console.WriteLine(debt);
         }

--- a/src/Chapter04/Listing04.02.Negative.cs
+++ b/src/Chapter04/Listing04.02.Negative.cs
@@ -5,7 +5,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter04.Listing04_02
         public static void Main()
         {
             //National Debt to the Penny
-            decimal debt = -18125876697430.99M;
+            decimal debt = -28382607800141.79M;
 
             System.Console.WriteLine(debt);
         }

--- a/src/Chapter04/Listing04.07.UnexpectedInequality.cs
+++ b/src/Chapter04/Listing04.07.UnexpectedInequality.cs
@@ -22,25 +22,19 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter04.Listing04_07
             System.Console.WriteLine(
                 $"(float){(float)decimalNumber}M != {floatNumber}F");
 
-            // Removing - float converted to double now matches the double
-            //Trace.Assert(doubleNumber1 != (double)floatNumber);
-            //// 4. Displays: 4.20000028610229 != 4.20000028610229
-            //System.Console.WriteLine(
-            //    $"{doubleNumber1} != {(double)floatNumber}");
-
-            // 5. Displays: 4.200000286102295 != 4.2
+            // 4. Displays: 4.200000286102295 != 4.2
             System.Console.WriteLine(
                 $"{doubleNumber1} != {doubleNumber2}");
 
-            // 6. Displays: 4.2000003F != 4.2D
+            // 5. Displays: 4.2000003F != 4.2D
             System.Console.WriteLine(
                 $"{floatNumber}F != {doubleNumber2}D");
 
-            // 7. Displays: 4.199999809265137 != 4.2
+            // 6. Displays: 4.199999809265137 != 4.2
             System.Console.WriteLine(
                 $"{(double)4.2F} != {4.2D}");
 
-            // 8. Displays: 4.2F != 4.2D
+            // 7. Displays: 4.2F != 4.2D
             System.Console.WriteLine(
                 $"{4.2F}F != {4.2D}D");
         }

--- a/src/Chapter04/Listing04.18.ComparingPrefixAndPostfix.cs
+++ b/src/Chapter04/Listing04.18.ComparingPrefixAndPostfix.cs
@@ -8,9 +8,9 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter04.Listing04_18
             // Displays 123, 124, 125
             System.Console.WriteLine($"{x++}, {x++}, {x}");
             // x now contains the value 125
-            // Displays 126, 127, 128
+            // Displays 126, 127, 127
             System.Console.WriteLine($"{++x}, {++x}, {x}");
-            // x now contains the value 128
+            // x now contains the value 127
         }
     }
 }

--- a/src/Shared/Program.cs
+++ b/src/Shared/Program.cs
@@ -45,7 +45,7 @@ namespace AddisonWesley.Michaelis.EssentialCSharp.Shared
             {
                 input = ParseListingName(input);
 
-                Regex reg = new Regex($"{input}\\.+");
+                Regex reg = new Regex($"Listing{input}\\.+");
 
                 IEnumerable<Type?> targets = assembly.GetTypes().Where(type =>
                 {


### PR DESCRIPTION
Errata: Added log of significant changes.
2.15: Added public identifiers to correct Reflection error.
2.17: Added a space in code to match book.
3.9/10/11/12/20/21/27/28: Replaced "Pascal" with "Visual Basic" to match book.
3.27: Removed whitespace for the additional example. 
4.18: Code comments for incrementing example were incorrect. They've been updated to match the book.
Program: Added "Listing" to Regex because it confused Listing.cs files with Table.cs files causing Listings 4.4/7.3/etc. to fail.