### PR TITLE
Change example .csproj extension to .csproj.xml for clarity in build

### DIFF
--- a/src/Chapter03/Listing03.03.EnablingNullableProjectWide.csproj.xml
+++ b/src/Chapter03/Listing03.03.EnablingNullableProjectWide.csproj.xml
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When running dotnet run on Chapter 3, the compiler didn't know which .csproj file to choose.
Also updated TargetFramework to net5.0.