### PR TITLE
CorrectChapter9ListingNumbers

### DIFF
--- a/src/Chapter09.Tests/Listing09.04.DeclaringRecordClass.Tests.cs
+++ b/src/Chapter09.Tests/Listing09.04.DeclaringRecordClass.Tests.cs
@@ -1,6 +1,6 @@
 namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_04.Tests;
 using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_01;
-using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_07;
+using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_06;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [TestClass]
@@ -23,7 +23,6 @@ public partial class CoordinateTests
             new Angle(180, 0, 0), new Angle(180, 0, 0));
         NamedCoordinate coordinate2 = new(
             coordinate1.Longitude, coordinate1.Latitude, "Test");
-        
 
         Assert.AreNotEqual<Type>(coordinate1.GetType(), coordinate2.GetType());
     }

--- a/src/Chapter09.Tests/Listing09.06.EquivalentRecordClassCode.Tests.cs
+++ b/src/Chapter09.Tests/Listing09.06.EquivalentRecordClassCode.Tests.cs
@@ -1,8 +1,8 @@
-namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_07.Tests;
+namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_06.Tests;
 
 using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_01;
 using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_04;
-using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_07;
+using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_06;
 
 [TestClass]
 public class CoordinateTests

--- a/src/Chapter09/Listing09.06.RecordClassInheritance.cs
+++ b/src/Chapter09/Listing09.06.RecordClassInheritance.cs
@@ -1,4 +1,4 @@
-namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_07;
+namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_06;
 using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_01;
 using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_04;
 

--- a/src/Chapter09/Listing09.07.CloningRecordsViaWithOperator.cs
+++ b/src/Chapter09/Listing09.07.CloningRecordsViaWithOperator.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_06A;
+namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_07;
 
 using AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_01;
 #region INCLUDE


### PR DESCRIPTION
- Swapped listing 9.6 and 9.7
- Updated namespace numbers

Fixes IntelliTect-dev/EssentialCSharp.Tooling#853
