### PR TITLE
fix: Update LangVersion to 12.0 from Preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>


### PR DESCRIPTION
BLOCKED until 12.0 actually releases and LangVersion 12.0 is supported (https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language#langversion)

Fixes #517 