### PR TITLE
Rev'ing test NuGets together 

### DIFF
--- a/src/Chapter01.Tests/Chapter01.Tests.csproj
+++ b/src/Chapter01.Tests/Chapter01.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-      <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+      <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter02.Tests/Chapter02.Tests.csproj
+++ b/src/Chapter02.Tests/Chapter02.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter03.Tests/Chapter03.Tests.csproj
+++ b/src/Chapter03.Tests/Chapter03.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <Import Project="..\ChapterTests.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Chapter03\Chapter03.csproj" />
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter04.Tests/Chapter04.Tests.csproj
+++ b/src/Chapter04.Tests/Chapter04.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter05.Tests/Chapter05.Tests.csproj
+++ b/src/Chapter05.Tests/Chapter05.Tests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter06.Tests/Chapter06.Tests.csproj
+++ b/src/Chapter06.Tests/Chapter06.Tests.csproj
@@ -4,13 +4,13 @@
   </PropertyGroup>
   <Import Project="..\ChapterTests.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
     <ProjectReference Include="..\Chapter06\Chapter06.csproj" />
     <PackageReference Update="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
   </ItemGroup>
 </Project>

--- a/src/Chapter07.Tests/Chapter07.Tests.csproj
+++ b/src/Chapter07.Tests/Chapter07.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter08.Tests/Chapter08.Tests.csproj
+++ b/src/Chapter08.Tests/Chapter08.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter09.Tests/Chapter09.Tests.csproj
+++ b/src/Chapter09.Tests/Chapter09.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <Import Project="..\ChapterTests.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Chapter09\Chapter09.csproj" />
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter10.Tests/Chapter10.Tests.csproj
+++ b/src/Chapter10.Tests/Chapter10.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter11.Tests/Chapter11.Tests.csproj
+++ b/src/Chapter11.Tests/Chapter11.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter12.Tests/Chapter12.Tests.csproj
+++ b/src/Chapter12.Tests/Chapter12.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter13.Tests/Chapter13.Tests.csproj
+++ b/src/Chapter13.Tests/Chapter13.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter14.Tests/Chapter14.Tests.csproj
+++ b/src/Chapter14.Tests/Chapter14.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter15.Tests/Chapter15.Tests.csproj
+++ b/src/Chapter15.Tests/Chapter15.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter16.Tests/Chapter16.Tests.csproj
+++ b/src/Chapter16.Tests/Chapter16.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter17.Tests/Chapter17.Tests.csproj
+++ b/src/Chapter17.Tests/Chapter17.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter18.Tests/Chapter18.Tests.csproj
+++ b/src/Chapter18.Tests/Chapter18.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter19.Tests/Chapter19.Tests.csproj
+++ b/src/Chapter19.Tests/Chapter19.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter20.Tests/Chapter20.Tests.csproj
+++ b/src/Chapter20.Tests/Chapter20.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter21.Tests/Chapter21.Tests.csproj
+++ b/src/Chapter21.Tests/Chapter21.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter22.Tests/Chapter22.Tests.csproj
+++ b/src/Chapter22.Tests/Chapter22.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />

--- a/src/Chapter23.Tests/Chapter23.Tests.csproj
+++ b/src/Chapter23.Tests/Chapter23.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.6.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Update="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
Because dependabot doesn't know to rev these together.