### PR TITLE
fix: Fix exclude

### DIFF
--- a/src/Chapter13/Listing13.21.StaticAnonymousFunctions.cs
+++ b/src/Chapter13/Listing13.21.StaticAnonymousFunctions.cs
@@ -31,7 +31,7 @@ public class Program
                 // Error CS8820: A static anonymous function
                 // cannot contain a reference to comparisonCount.
                 comparisonCount++;
-                #endif // COMPILEERROR EXCLUDE
+                #endif // COMPILEERROR // EXCLUDE
                 return first < second;
             }
         );


### PR DESCRIPTION
It wouldn't parse because it was missing the `//` before the EXCLUDE