### PR TITLE
feat: Update listing 9.36 to include linux

### DIFF
--- a/src/Chapter09.Tests/Listing09.36.UsingBitwiseORandANDWithFlagEnums.Tests.cs
+++ b/src/Chapter09.Tests/Listing09.36.UsingBitwiseORandANDWithFlagEnums.Tests.cs
@@ -1,30 +1,19 @@
-using System.Runtime.InteropServices;
-
 namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter09.Listing09_36.Tests;
 
 [TestClass]
 public class ProgramTests
 {
     [TestMethod]
-    public void Main_ExpectHiddentAndReadOnlyFlags()
+    public void Main_ExpectHiddenAndReadOnlyFlags()
     {
         Directory.SetCurrentDirectory(AppContext.BaseDirectory);
         FileAttributes fileAttributes;
         string expected;
 
-        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            // The only working file attribute on Linux is ReadOnly.
-            fileAttributes = FileAttributes.ReadOnly;
-            Assert.AreEqual<int>(1, (int)fileAttributes);
-            expected = $@"ReadOnly = {(int)fileAttributes}";
-        }
-        else
-        {
-            fileAttributes = FileAttributes.Hidden | FileAttributes.ReadOnly;
-            Assert.AreEqual<int>(3, (int)fileAttributes);
-            expected = $@"ReadOnly, Hidden = {(int)fileAttributes}";
-        }
+        fileAttributes = FileAttributes.Hidden | FileAttributes.ReadOnly;
+        Assert.AreEqual<int>(3, (int)fileAttributes);
+        expected = $@"ReadOnly, Hidden = {(int)fileAttributes}";
+
         
         IntelliTect.TestTools.Console.ConsoleAssert.Expect(
             expected, Program.Main);

--- a/src/Chapter09/Listing09.36.UsingBitwiseORandANDWithFlagEnums.cs
+++ b/src/Chapter09/Listing09.36.UsingBitwiseORandANDWithFlagEnums.cs
@@ -10,7 +10,7 @@ public class Program
     {
         // ...
 
-        string fileName = @"enumtest.txt";
+        string fileName = @".enumtest.txt";
 
         #region EXCLUDE
         System.IO.FileInfo enumFile = new(fileName);
@@ -21,23 +21,18 @@ public class Program
 
         try
         {
-        #endregion EXCLUDE
-            System.IO.FileInfo file = new(fileName);
-
-            file.Attributes = FileAttributes.Hidden |
-                FileAttributes.ReadOnly;
+            #endregion EXCLUDE
+            System.IO.FileInfo file = new(fileName)
+            {
+                Attributes = FileAttributes.Hidden |
+                FileAttributes.ReadOnly
+            };
 
             Console.WriteLine($"{file.Attributes} = {(int)file.Attributes}");
 
-            // Only the ReadOnly attribute works on Linux
-            // (The Hidden attribute does not work on Linux)
-            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            if (!file.Attributes.HasFlag(FileAttributes.Hidden))
             {
-                // Added in C# 4.0/Microsoft .NET Framework  4.0
-                if (!file.Attributes.HasFlag(FileAttributes.Hidden))
-                {
-                    throw new Exception("File is not hidden.");
-                }
+                throw new Exception("File is not hidden.");
             }
 
             if ((file.Attributes & FileAttributes.ReadOnly) !=


### PR DESCRIPTION
Fixes #117

A file name that starts with a `.` on linux is considered hidden.