### PR TITLE
fix: Listing07.24.RelationalPatternWithIsOperator.cs - Use the unused `hour` assignment

### DIFF
--- a/src/Chapter07.Tests/Listing07.24.Tests.cs
+++ b/src/Chapter07.Tests/Listing07.24.Tests.cs
@@ -42,6 +42,10 @@ public class PeriodsOfTheDayTests
     [TestMethod]
     public void GetPeriodOfDay_InvalidHour_ReturnsInvalid()
     {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => PeriodsOfTheDay.GetPeriodOfDay(25));
+        int invalidHour = 25;
+
+        var exceptionThrown = Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+        PeriodsOfTheDay.GetPeriodOfDay(invalidHour));
+        Assert.IsTrue(exceptionThrown.Message.StartsWith($"The hour of the day specified ({invalidHour}) is invalid."));
     }
 }

--- a/src/Chapter07/Listing07.24.RelationalPatternWithIsOperator.cs
+++ b/src/Chapter07/Listing07.24.RelationalPatternWithIsOperator.cs
@@ -17,7 +17,7 @@ public class PeriodsOfTheDay
             < 18 => "Afternoon",
             < 24 => "Evening",
             int hour => throw new ArgumentOutOfRangeException(nameof(hourOfTheDay), 
-                $"The hour of the day specified is invalid.")
+                $"The hour of the day specified ({hour}) is invalid.")
         };
     #endregion INCLUDE
 }


### PR DESCRIPTION
Use unused hour