### PR TITLE
Chapter13.15 bug fix

### DIFF
--- a/Errata.md
+++ b/Errata.md
@@ -41,3 +41,4 @@ Zhou Jing | 22 | 1065 - 1066 | Changed 'Thread' to 'Task' and "Application exiti
 Zhou Jing | 4 | 161 | Fix `input < 9` to `input < 0` in Listing 4.24
 Zhou Jing    | 4 | 119 | Show inconsistent size multi-dimensional array in listing 3.16
 Zhou Jing | 3  | 114 | Replace `second` with `third` in "// Retrieve third item from the end (Python)"
+Tyler Woody | 13 | 702 | Remove the `!` negation in `string.IsNullOrWhiteSpace(input)` in the while loop to properly allow looping

--- a/src/Chapter13.Tests/Listing13.15.Tests.cs
+++ b/src/Chapter13.Tests/Listing13.15.Tests.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+
+namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter13.Listing13_15.Tests;
+
+[TestClass]
+public class ProgramTests
+{
+    [TestMethod]
+    public void MainTest()
+    {
+        const string expectedInput = "Hello, World!";
+        const string expectedOutput = "Hello, World!";
+
+        StringReader reader = new (expectedInput);
+        StringWriter writer = new ();
+        try
+        {
+            Console.SetIn(reader);
+            Console.SetOut(writer);
+            Program.Main();
+
+            string actualOutput = writer.ToString().Trim();
+            Assert.AreEqual(expectedOutput, actualOutput);
+        }
+        finally
+        {
+            reader.Dispose();
+            writer.Dispose();
+        }
+    }
+}

--- a/src/Chapter13.Tests/Listing13.15.Tests.cs
+++ b/src/Chapter13.Tests/Listing13.15.Tests.cs
@@ -1,5 +1,4 @@
-﻿
-namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter13.Listing13_15.Tests;
+﻿namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter13.Listing13_15.Tests;
 
 [TestClass]
 public class ProgramTests
@@ -7,18 +6,10 @@ public class ProgramTests
     [TestMethod]
     public void MainTest()
     {
-        const string expectedOutput = "ValidInput";
-        string simulatedInput = "\n   \nValidInput\n";
+        const string expected = "<<ValidInput>>ValidInput";
 
         IntelliTect.TestTools.Console.ConsoleAssert.Expect(
-            expectedOutput,
-            () =>
-            {
-                using (StringReader simulatedReader = new (simulatedInput))
-                {
-                    Console.SetIn(simulatedReader);
-                    Program.Main();
-                }
-            });
+            expected, Program.Main
+        );
     }
 }

--- a/src/Chapter13.Tests/Listing13.15.Tests.cs
+++ b/src/Chapter13.Tests/Listing13.15.Tests.cs
@@ -7,24 +7,18 @@ public class ProgramTests
     [TestMethod]
     public void MainTest()
     {
-        const string expectedInput = "Hello, World!";
-        const string expectedOutput = "Hello, World!";
+        const string expectedOutput = "ValidInput";
+        string simulatedInput = "\n   \nValidInput\n";
 
-        StringReader reader = new (expectedInput);
-        StringWriter writer = new ();
-        try
-        {
-            Console.SetIn(reader);
-            Console.SetOut(writer);
-            Program.Main();
-
-            string actualOutput = writer.ToString().Trim();
-            Assert.AreEqual(expectedOutput, actualOutput);
-        }
-        finally
-        {
-            reader.Dispose();
-            writer.Dispose();
-        }
+        IntelliTect.TestTools.Console.ConsoleAssert.Expect(
+            expectedOutput,
+            () =>
+            {
+                using (StringReader simulatedReader = new (simulatedInput))
+                {
+                    Console.SetIn(simulatedReader);
+                    Program.Main();
+                }
+            });
     }
 }

--- a/src/Chapter13.Tests/Listing13.15.Tests.cs
+++ b/src/Chapter13.Tests/Listing13.15.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-
+﻿
 namespace AddisonWesley.Michaelis.EssentialCSharp.Chapter13.Listing13_15.Tests;
 
 [TestClass]

--- a/src/Chapter13/Listing13.15.ParameterlessStatementLambdas.cs
+++ b/src/Chapter13/Listing13.15.ParameterlessStatementLambdas.cs
@@ -22,6 +22,7 @@ public class Program
             };
         //...
         #endregion INCLUDE
-        Console.WriteLine(getUserInput());
+        string input = getUserInput();
+        Console.WriteLine(input);
     }
 }

--- a/src/Chapter13/Listing13.15.ParameterlessStatementLambdas.cs
+++ b/src/Chapter13/Listing13.15.ParameterlessStatementLambdas.cs
@@ -17,11 +17,11 @@ public class Program
                 {
                     input = Console.ReadLine();
                 }
-                while(!string.IsNullOrWhiteSpace(input));
+                while(string.IsNullOrWhiteSpace(input));
                 return input!;
             };
         //...
         #endregion INCLUDE
-        getUserInput();
+        Console.WriteLine(getUserInput());
     }
 }


### PR DESCRIPTION
## Summary
This pull request addresses an issue in `Chapter13.15.ParameterlessStatementLambdas.cs` where `getUserInput` was only taking white space as input. The method has been updated to ensure that only valid, non-whitespace strings are accepted.

## Changes Made
- Removed the Not (`!`) on the while loop condition in `getUserInput` to properly handle whitespace inputs.
- Updated 'Main' to call `Console.WriteLine(input);` for testing.
- Added unit test to verify correct behavior for valid inputs.