### PR TITLE
fix: Manually Pin Microsoft.NETCore.App.Ref version for .net 6.0 runtime

### DIFF
--- a/src/Shared/Tests/CompilerAssert.cs
+++ b/src/Shared/Tests/CompilerAssert.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -41,11 +41,11 @@ public static class CompilerAssert
         {
             CompilerDiagnostics = CompilerDiagnostics.Warnings,
             ReferenceAssemblies = new ReferenceAssemblies(
-                        $"net{Environment.Version.Major}.{Environment.Version.Minor}",
+                        Environment.Version.Major == 6 ? "net6.0" : $"net{Environment.Version.Major}.{Environment.Version.Minor}",
                         new PackageIdentity(
                             "Microsoft.NETCore.App.Ref",
-                            NetCore.GetNetCoreVersion()),
-                        Path.Combine("ref", $"net{Environment.Version.Major}.{Environment.Version.Minor}"))
+                            Environment.Version.Major == 6 ? "6.0.36" : NetCore.GetNetCoreVersion()),
+                        Path.Combine("ref", Environment.Version.Major == 6 ? "net6.0" : $"net{Environment.Version.Major}.{Environment.Version.Minor}"))
         };
 
         List<string> fileNamesToCompile = new();


### PR DESCRIPTION
Pin Ref Version for net6.0 package as there is not an associated 6.0.37 version available at this time (https://www.nuget.org/packages/Microsoft.NETCore.App.Ref/6.0.36)

However our runners appear to have that version of the runtime available:

![image](https://github.com/user-attachments/assets/4a22bd43-3f92-4895-805f-789fea277423)
